### PR TITLE
Read token type from contract, for Plasma Tokens

### DIFF
--- a/root/src/mappings/registry.ts
+++ b/root/src/mappings/registry.ts
@@ -1,4 +1,4 @@
-import { Address } from '@graphprotocol/graph-ts'
+import { Address, Bytes } from '@graphprotocol/graph-ts'
 
 import { Registry, TokenMapped } from '../../generated/Registry/Registry'
 import { TokenMapping } from '../../generated/schema'
@@ -26,7 +26,7 @@ export function handlePlasmaTokenMapped(event: TokenMapped): void {
   // 1. keccak256('ERC721') = 0x73ad2146b3d3a286642c794379d750360a2d53a3459a11b3e5d6cc900f55f44a
   // 2. keccak256('ERC20') = 0x8ae85d849167ff996c04040c44924fd364217285e4cad818292c7ac37c0a345b
   let registry = Registry.bind(Address.fromString(registryAddress))
-  entity.tokenType = registry.isERC721(event.params.rootToken) ? '0x73ad2146b3d3a286642c794379d750360a2d53a3459a11b3e5d6cc900f55f44a' : '0x8ae85d849167ff996c04040c44924fd364217285e4cad818292c7ac37c0a345b'
+  entity.tokenType = (registry.isERC721(event.params.rootToken) ? '0x73ad2146b3d3a286642c794379d750360a2d53a3459a11b3e5d6cc900f55f44a' : '0x8ae85d849167ff996c04040c44924fd364217285e4cad818292c7ac37c0a345b') as Bytes
 
   // Yes, this is plasma mapping handler, so it's a plasma bridge token
   entity.isPOS = false

--- a/root/src/mappings/registry.ts
+++ b/root/src/mappings/registry.ts
@@ -1,5 +1,15 @@
+import { Address } from '@graphprotocol/graph-ts'
+
 import { TokenMapped } from '../../generated/Registry/Registry'
 import { TokenMapping } from '../../generated/schema'
+
+// Using contract address for creating instance of `Registry`
+// contract, to be used for checking whether token is ERC20/ ERC721
+import { registryAddress } from '../network'
+
+// This is the contract we're going to interact with when `TokenMapped` event is emitted
+// to check what kind of token it is
+import { Registry } from '../../generated/Registry/Registry'
 
 export function handlePlasmaTokenMapped(event: TokenMapped): void {
   let id = 'plasma-token-mapping-' + event.params.rootToken.toHexString()
@@ -11,6 +21,18 @@ export function handlePlasmaTokenMapped(event: TokenMapped): void {
 
   entity.rootToken = event.params.rootToken
   entity.childToken = event.params.childToken
+
+  // Attempting to check from `Registry` contract what kind of
+  // token it is.
+  //
+  // `tokenType` will be any of two possible values for Plasma Tokens
+  //
+  // 1. keccak256('ERC721') = 0x73ad2146b3d3a286642c794379d750360a2d53a3459a11b3e5d6cc900f55f44a
+  // 2. keccak256('ERC20') = 0x8ae85d849167ff996c04040c44924fd364217285e4cad818292c7ac37c0a345b
+  let registry = Registry.bind(Address.fromString(registryAddress))
+  entity.tokenType = registry.isERC721(event.params.rootToken) ? '0x73ad2146b3d3a286642c794379d750360a2d53a3459a11b3e5d6cc900f55f44a' : '0x8ae85d849167ff996c04040c44924fd364217285e4cad818292c7ac37c0a345b'
+
+  // Yes, this is plasma mapping handler, so it's a plasma bridge token
   entity.isPOS = false
 
   entity.timestamp = event.block.timestamp

--- a/root/src/mappings/registry.ts
+++ b/root/src/mappings/registry.ts
@@ -1,15 +1,11 @@
 import { Address } from '@graphprotocol/graph-ts'
 
-import { TokenMapped } from '../../generated/Registry/Registry'
+import { Registry, TokenMapped } from '../../generated/Registry/Registry'
 import { TokenMapping } from '../../generated/schema'
 
 // Using contract address for creating instance of `Registry`
 // contract, to be used for checking whether token is ERC20/ ERC721
 import { registryAddress } from '../network'
-
-// This is the contract we're going to interact with when `TokenMapped` event is emitted
-// to check what kind of token it is
-import { Registry } from '../../generated/Registry/Registry'
 
 export function handlePlasmaTokenMapped(event: TokenMapped): void {
   let id = 'plasma-token-mapping-' + event.params.rootToken.toHexString()

--- a/root/src/network.template.ts
+++ b/root/src/network.template.ts
@@ -1,2 +1,3 @@
 export const network: string = '{{ network }}'
 export const stakingNftAddress: string = '{{ contracts.stakingNft.address }}'
+export const registryAddress: string = '{{ contracts.registry.address }}'


### PR DESCRIPTION
This PR attempts to add support for subgraphs trying to read state of `isERC721` mapping in Registry contract, so that we can store token type in subgraph when processing Plasma token mapping request.