### PR TITLE
sync data to string

### DIFF
--- a/root/schema.graphql
+++ b/root/schema.graphql
@@ -18,7 +18,7 @@ type StateSync @entity {
   syncType: Int!
   depositorOrRootToken: String!
   depositedTokenOrChildToken: String!
-  data: Bytes!
+  data: String!
   transactionHash: Bytes!
   timestamp: BigInt!
 }

--- a/root/src/mappings/state-sync.ts
+++ b/root/src/mappings/state-sync.ts
@@ -35,7 +35,7 @@ export function handleStateSynced(event: StateSynced): void {
     entity.syncType = -1
     entity.depositorOrRootToken = '0x'
     entity.depositedTokenOrChildToken = '0x'
-    entity.data = event.params.data
+    entity.data = event.params.data.toString()
 
     // save entity
     entity.save()
@@ -51,7 +51,7 @@ export function handleStateSynced(event: StateSynced): void {
   entity.syncType = decoded.value0
   entity.depositorOrRootToken = decoded.value1.toHex()
   entity.depositedTokenOrChildToken = decoded.value2.toHex()
-  entity.data = decoded.value3
+  entity.data = decoded.value3.toString()
 
   // save entity
   entity.save()

--- a/root/src/mappings/withdraw-manager.ts
+++ b/root/src/mappings/withdraw-manager.ts
@@ -52,6 +52,7 @@ export function handleExitCancelled(event: ExitCancelled): void {
   if (entity == null) {
     entity = new PlasmaExit(id)
 
+    entity.counter = BigInt.fromI32(0)
     entity.isRegularExit = true
     entity.exited = 1
   }
@@ -77,6 +78,7 @@ export function handleWithdraw(event: Withdraw): void {
   if (entity == null) {
     entity = new PlasmaExit(id)
 
+    entity.counter = BigInt.fromI32(0)
     entity.isRegularExit = true
     entity.exited = 2
   }


### PR DESCRIPTION
Graph made a change in their code base that affects lengthy bytes data. 

State Sync data is converted to string in the schema from bytes.