### PR TITLE
Query filter StakingParams entity 

### DIFF
--- a/root/schema.graphql
+++ b/root/schema.graphql
@@ -208,7 +208,9 @@ type Topup @entity {
 }
 
 # Staking Params across all validators
-type StakingParams @entity {
+type StakingParams
+  @queryFields(singular: "stakingParams", plural: "allStakingParams")
+  @entity {
   id: ID!
   owner: Bytes
   validatorThreshold: BigInt!


### PR DESCRIPTION
Adding query filter on StakingParams entity, due to [entity cannot end in \`s`](https://github.com/graphprotocol/support/issues/12) issue in GraphQL.